### PR TITLE
Develop

### DIFF
--- a/src/Single/Encoder.h
+++ b/src/Single/Encoder.h
@@ -6,6 +6,9 @@
 namespace EncoderTool
 {
     // Simple encoder implementation which reads phase A and B from two digital pins
+    // It uses attachInterruptEx to attach callbacks with type void(*)(Encoder*).
+    // We don't use std::function<> here to reduce memory footprint for small MCUs like the T-LC
+
     class Encoder : public EncoderBase
     {
      public:
@@ -34,8 +37,8 @@ namespace EncoderTool
         pinMode(pinA, inputMode);
         pinMode(pinB, inputMode);
 
-        attachInterruptEx(pinA, [this] { update(digitalReadFast(pinA), digitalReadFast(pinB)); }, CHANGE);
-        attachInterruptEx(pinB, [this] { update(digitalReadFast(pinA), digitalReadFast(pinB)); }, CHANGE);
+        attachInterruptEx(pinA,[](Encoder* THIS){THIS->update(digitalReadFast(THIS->pinA), digitalReadFast(THIS->pinB));}, this, CHANGE);
+        attachInterruptEx(pinB,[](Encoder* THIS){THIS->update(digitalReadFast(THIS->pinA), digitalReadFast(THIS->pinB));}, this, CHANGE);
 
         setCountMode(countMode);
         EncoderBase::begin(digitalReadFast(pinA), digitalReadFast(pinB)); // set start state
@@ -46,5 +49,4 @@ namespace EncoderTool
         detachInterrupt(pinA);
         detachInterrupt(pinB);
     }
-
 } // namespace EncoderTool

--- a/src/Single/attachInterruptEx.h
+++ b/src/Single/attachInterruptEx.h
@@ -1,6 +1,11 @@
 #pragma once
-#include <functional>
 
-extern void attachInterruptEx(unsigned pin, std::function<void(void)>, int mode);
+namespace EncoderTool
+{
+    class Encoder;
 
-// to detach the intterrupt, the standard detachInterrupt can be used
+    using state_t = Encoder*;             // we directly use an Encoder* as state variable to avoid casts from void* to Encoder* in the ISR
+    using cb_t = void (*)(state_t state); // callback type
+
+    void attachInterruptEx(unsigned pin, cb_t callback, state_t state, int mode);
+}

--- a/src/config.h
+++ b/src/config.h
@@ -1,32 +1,29 @@
 #pragma once
 
-
 // un-comment the following line if you prefer plain function pointers for callbacks
-//#define PLAIN_ENC_CALLBACK
-
-// un-comment the following line if you need callbacks for code errors
-//#define USE_ERROR_CALLBACKS
-
+// #define PLAIN_ENC_CALLBACK
 
 //================================================================================================================
 
 #include <cstdint>
 
 #if not defined(PLAIN_ENC_CALLBACK)
-    #include <functional>
-   // inline void std::__throw_bad_function_call(){while (1) {}}  // do whatever you want to do instead of an exception
+  #include <functional>
 #endif
 
 namespace EncoderTool
 {
-    #if defined(PLAIN_ENC_CALLBACK)
-        using encCallback_t = void (*)(int32_t value);
-        using allCallback_t = void (*)(uint32_t nr, int32_t value);
-    #else
-        using encCallback_t = std::function<void(int32_t value, int32_t delta)>;   // encoder value
-        using encBtnCallback_t = std::function<void(int32_t state)>;               // encoder button
+#if defined(PLAIN_ENC_CALLBACK)
+    using encCallback_t = void (*)(int32_t value, int32_t delta);
+    using encBtnCallback_t = void (*)(int32_t state);
 
-        using allCallback_t = std::function<void(uint32_t channel, int32_t value, int32_t delta)>;  // all encoder values
-        using allBtnCallback_t = std::function<void(uint32_t channel, int32_t state)>;              // all encoder buttons
-    #endif
+    using allCallback_t = void (*)(uint32_t channel, int32_t value, int32_t delta);
+    using allBtnCallback_t = void (*)(int32_t state);
+#else
+    using encCallback_t = std::function<void(int32_t value, int32_t delta)>; // encoder value
+    using encBtnCallback_t = std::function<void(int32_t state)>;             // encoder button
+
+    using allCallback_t = std::function<void(uint32_t channel, int32_t value, int32_t delta)>; // all encoder values
+    using allBtnCallback_t = std::function<void(uint32_t channel, int32_t state)>;             // all encoder buttons
+#endif
 }


### PR DESCRIPTION
Reduces memory footprint which might be interesting for smaller MCUs like the one from the Teensy-LC
Fixes the option to use plain vanilla void(*)(void) callbacks 