### PR TITLE
feat: Add button callback to multiplexed

### DIFF
--- a/src/Multiplexed/EncPlex4051.h
+++ b/src/Multiplexed/EncPlex4051.h
@@ -1,7 +1,11 @@
 #pragma once
-#include "Arduino.h"
-#include "EncPlexBase.h"
+
 #include "HAL/directReadWrite.h"
+#include "../delay.h"
+#include "Arduino.h"
+#include "Bounce2.h"
+#include "EncPlexBase.h"
+
 
 namespace EncoderTool
 {
@@ -9,22 +13,20 @@ namespace EncoderTool
     class EncPlex4051_tpl : public EncPlexBase<counter_t>
     {
      public:
-        inline EncPlex4051_tpl(unsigned encoderCount, unsigned pinS0, unsigned pinS1, unsigned pinS2, unsigned pinA, unsigned pinB);
+        inline EncPlex4051_tpl(unsigned encoderCount, unsigned pinS0, unsigned pinS1, unsigned pinS2, unsigned pinA, unsigned pinB,  unsigned pinBtn = -1);
 
         inline void tick(); // call as often as possible
         inline void begin(CountMode mode = CountMode::quarter);
 
      protected:
-        const HAL::pinRegInfo_t S0, S1, S2, A, B;
+        const HAL::pinRegInfo_t S0, S1, S2, A, B, Btn;
     };
 
     // IMPLEMENTATION =====================================================================================================
 
     template <typename counter_t>
-    EncPlex4051_tpl<counter_t>::EncPlex4051_tpl(unsigned encoderCount, unsigned pinS0, unsigned pinS1, unsigned pinS2, unsigned pinA, unsigned pinB)
-        : EncPlexBase<counter_t>(encoderCount),
-          S0(pinS0), S1(pinS1), S2(pinS2),
-          A(pinA), B(pinB)
+    EncPlex4051_tpl<counter_t>::EncPlex4051_tpl(unsigned encoderCount, unsigned pinS0, unsigned pinS1, unsigned pinS2, unsigned pinA, unsigned pinB, unsigned pinBtn)
+        : EncPlexBase<counter_t>(encoderCount), S0(pinS0), S1(pinS1), S2(pinS2), A(pinA), B(pinB), Btn(pinBtn)
     {
     }
 
@@ -37,6 +39,7 @@ namespace EncoderTool
         pinMode(S2.pin, OUTPUT);
         pinMode(A.pin, INPUT);
         pinMode(B.pin, INPUT);
+        if (Btn.pin < NUM_DIGITAL_PINS) pinMode(Btn.pin, INPUT);
     }
 
     template <typename counter_t>
@@ -52,10 +55,13 @@ namespace EncoderTool
             directWrite(S2, i & 0b0100);
             delayMicroseconds(1);
 
-            int delta = EncPlexBase<counter_t>::encoders[i].update(directRead(A), directRead(B));
+            int delta = EncPlexBase<counter_t>::encoders[i].update(directRead(A), directRead(B), Btn.pin < NUM_DIGITAL_PINS ? directRead(Btn) : LOW);;
             if (delta != 0 && EncPlexBase<counter_t>::callback != nullptr)
             {
                 EncPlexBase<counter_t>::callback(i, EncPlexBase<counter_t>::encoders[i].getValue(), delta);
+            }
+            if (EncPlexBase<counter_t>::btnCallback != nullptr && EncPlexBase<counter_t>::encoders[i].buttonChanged()) {
+                EncPlexBase<counter_t>::btnCallback(i, EncPlexBase<counter_t>::encoders[i].getButton());
             }
         }
     }

--- a/src/Multiplexed/EncPlexBase.h
+++ b/src/Multiplexed/EncPlexBase.h
@@ -18,6 +18,7 @@ namespace EncoderTool
 #endif
 
         void attachCallback(allCallback_t callback);
+        void attachButtonCallback(allBtnCallback_t btnCallback);
         EncoderBase<counter_t>& operator[](size_t idx);
 
      protected:
@@ -25,12 +26,13 @@ namespace EncoderTool
         ~EncPlexBase();
 
         void begin(CountMode mode = CountMode::quarter);
-        void begin(allCallback_t, CountMode mode = CountMode::quarter);
+        // void begin(allCallback_t, allBtnCallback_t, CountMode mode = CountMode::quarter);
 
         const size_t encoderCount;
         EncoderBase<counter_t>* encoders;
 
         allCallback_t callback = nullptr;
+        allBtnCallback_t btnCallback = nullptr;
         counter_t c;
     };
 
@@ -66,5 +68,11 @@ namespace EncoderTool
     void EncPlexBase<counter_t>::attachCallback(allCallback_t _callback)
     {
         callback = _callback;
+    }
+
+    template <typename counter_t>
+    void EncPlexBase<counter_t>::attachButtonCallback(allBtnCallback_t _btnCallback)
+    {
+        btnCallback = _btnCallback;
     }
 }


### PR DESCRIPTION
I've added support for buttonCallback for multiplexed encoders.

I have one comment on my implementation. 
In src/Multiplexed/EncPlex4051.h at line 63 I call buttonChanged() but that function switches the btnChanged state in EncoderBase.h this means that  normal use of encoder[x].buttonChanged() will not work after encoders.tick()

