### PR TITLE
Make error callback work

### DIFF
--- a/src/EncoderBase.h
+++ b/src/EncoderBase.h
@@ -272,7 +272,7 @@ namespace EncoderTool
         if (direction == ERR)
         {
             if (errCallback != nullptr)
-                errCallback(value);
+                errCallback(value,999);
         }
 #endif
         return false;

--- a/src/config.h
+++ b/src/config.h
@@ -2,6 +2,7 @@
 
 // comment the following line out if you prefer plain vanilla function pointers for callbacks
 #define WANT_MODERN_CALLBACKS
+#define USE_ERROR_CALLBACKS
 
 //================================================================================================================
 


### PR DESCRIPTION
Fixed the error callback so you don't get a compilation error if it's used. I also enabled it in `config.h` - you might prefer to revert that. The error callback gives a weird delta value of 999, since we can't know the true value - again, you may prefer another value.

Done in response to [this post](https://forum.pjrc.com/index.php?threads/does-tycommander-handle-ftdi-or-am-i-doing-something-wrong.77159/post-360668) on the Teensy forum.